### PR TITLE
Attempting to change the working directory for Pulumi

### DIFF
--- a/.github/workflows/pulumi.yml
+++ b/.github/workflows/pulumi.yml
@@ -32,6 +32,7 @@ jobs:
       - name: Deploy with Pulumi
         uses: pulumi/actions@v5
         with:
+          work-dir: $GITHUB_WORKSPACE/infra/
           command: up
           stack-name: applied-curiosity/bcamp_data_platform_azure/dev1
         env:


### PR DESCRIPTION
Pulumi is failing at the up command and claiming there is no project file, and this is likely because we have our project file in the infra folder. I'm attempting to set the working directory as Infra. 